### PR TITLE
Add support for overriding target frameworks.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,4 +18,11 @@
         <None Include="..\logos\tommy_logo_icon.png" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>
 
+    <PropertyGroup>
+        <ParentDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))</ParentDirectoryBuildPropsPath>
+    </PropertyGroup>
+
+    <ImportGroup>
+        <Import Project="$(ParentDirectoryBuildPropsPath)" />
+    </ImportGroup>
 </Project>

--- a/Tommy.Extensions.Configuration/Tommy.Extensions.Configuration.csproj
+++ b/Tommy.Extensions.Configuration/Tommy.Extensions.Configuration.csproj
@@ -1,12 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <Version>6.0.0</Version>
         <Authors>$(Authors), js6pak</Authors>
         <PackageTags>TOML,extension</PackageTags>
         <Description>Extensions for Tommy to use with Microsoft.Extensions.Configuration.</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TommyExtensionsConfiguration_TargetFrameworksToBuild)' == '' ">
+        <TommyExtensionsConfiguration_TargetFrameworksToBuild>$(Tommy_TargetFrameworksToBuild)</TommyExtensionsConfiguration_TargetFrameworksToBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensionsConfiguration_TargetFrameworksToBuild)' == '' ">
+        <TommyExtensionsConfiguration_TargetFrameworksToBuild>$(TargetFrameworksToBuild)</TommyExtensionsConfiguration_TargetFrameworksToBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensionsConfiguration_TargetFrameworksToBuild)' == '' ">
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensionsConfiguration_TargetFrameworksToBuild)' != '' ">
+        <TargetFrameworks>$(TommyExtensionsConfiguration_TargetFrameworksToBuild)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tommy.Extensions/Tommy.Extensions.csproj
+++ b/Tommy.Extensions/Tommy.Extensions.csproj
@@ -1,11 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
         <Version>2.0.0</Version>
         <PackageTags>TOML,parser,writer,simple,extension</PackageTags>
         <Description>Extensions for Tommy to allow higher level access to TOML parser and writer.</Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TommyExtensions_TargetFrameworksToBuild)' == '' ">
+        <TommyExtensions_TargetFrameworksToBuild>$(Tommy_TargetFrameworksToBuild)</TommyExtensions_TargetFrameworksToBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensions_TargetFrameworksToBuild)' == '' ">
+        <TommyExtensions_TargetFrameworksToBuild>$(TargetFrameworksToBuild)</TommyExtensions_TargetFrameworksToBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensions_TargetFrameworksToBuild)' == '' ">
+        <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TommyExtensions_TargetFrameworksToBuild)' != '' ">
+        <TargetFrameworks>$(TommyExtensions_TargetFrameworksToBuild)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tommy/Tommy.csproj
+++ b/Tommy/Tommy.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
         <Version>3.0.1</Version>
         <PackageTags>TOML,parser,writer,simple</PackageTags>
         <Description>
@@ -10,6 +9,16 @@
             Compliant with TOML 1.0.0 format spec.
         </Description>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Tommy_TargetFrameworksToBuild)' == '' ">
+        <Tommy_TargetFrameworksToBuild>$(TargetFrameworksToBuild)</Tommy_TargetFrameworksToBuild>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Tommy_TargetFrameworksToBuild)' == '' ">
+        <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Tommy_TargetFrameworksToBuild)' != '' ">
+        <TargetFrameworks>$(Tommy_TargetFrameworksToBuild)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This allows override the `TargetFrameworks` that Tommy uses, if you include the project itself in your solution, via adding something like this to a parent directory's `Directory.Build.props`:

```xml
<Project>
  <PropertyGroup>
    <Tommy_TargetFrameworksToBuild>net48</Tommy_TargetFrameworksToBuild>
    <TommyExtensions_TargetFrameworksToBuild>net48</TommyExtensions_TargetFrameworksToBuild>
    <TommyExtensionsConfiguration_TargetFrameworksToBuild>net48</TommyExtensionsConfiguration_TargetFrameworksToBuild>
  </PropertyGroup>
</Project>
```

For the main project, it will try:
* `Tommy_TargetFrameworksToBuild`
* `TargetFrameworksToBuild`

Otherwise defaults to the original `TargetFrameworks`.

For the extensions projects, it will try:
* `TommyExtensions_TargetFrameworksToBuild`/`TommyExtensionsConfiguration_TargetFrameworksToBuild`
* `Tommy_TargetFrameworksToBuild`
* `TargetFrameworksToBuild`

Otherwise defaults to the original `TargetFrameworks`.
